### PR TITLE
Compile as per arch

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,32 @@ function getPath(compilation, outputPath, outputFilename, extension) {
   return relativeOutputPath;
 }
 
+function compileArch(compilation, outputPath, outputFilename, arch, callback) {
+  const zipFilePath = getPath(compilation, outputPath, `${outputFilename}-${arch}`, ".zip");
+
+  if (arch === "armv7l") {
+    getData(__dirname + "/lnx-armv7l/unzipsfx")
+      .then((data)=> {
+        let linuxBuffer = Buffer.concat([data, compilation.assets[zipFilePath].source()]);
+        compilation.assets[getPath(compilation, outputPath, outputFilename + "-lnx-armv7l", ".sh")] = new RawSource(linuxBuffer);
+      })
+      .then(callback);
+  } else {
+    getData(__dirname + `/lnx-${arch}/unzipsfx`)
+      .then((data)=> {
+        let linuxBuffer = Buffer.concat([data, compilation.assets[zipFilePath].source()]);
+        compilation.assets[getPath(compilation, outputPath, `${outputFilename}-lnx-${arch}`, ".sh")] = new RawSource(linuxBuffer);
+
+        return getData(__dirname + "/win/unzipsfx.exe");
+      })
+      .then((data)=>{
+        let windowsBuffer = Buffer.concat([data, compilation.assets[zipFilePath].source()]);
+        compilation.assets[getPath(compilation, outputPath, `${outputFilename}-win-${arch}`, ".exe")] = new RawSource(windowsBuffer);
+      })
+      .then(callback);
+  }
+}
+
 UnzipsfxPlugin.prototype.apply = function(compiler) {
   const options = this.options;
 	compiler.plugin('emit', function(compilation, callback) {
@@ -42,6 +68,12 @@ UnzipsfxPlugin.prototype.apply = function(compiler) {
 		}
     const outputPath = options.outputPath || compilation.options.output.path;
     const outputFilename = options.outputFilename || compilation.options.output.filename || path.basename(outputPath);
+
+    if (options.arch) {
+      compileArch(compilation, outputPath, outputFilename, options.arch, callback);
+      return;
+    }
+
     const zipFilePath = getPath(compilation, outputPath, outputFilename, ".zip");
 
     getData(__dirname + "/lnx-32/unzipsfx")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "unzipsfx-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "source-list-map": {
       "version": "2.0.0",
@@ -16,7 +17,11 @@
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw=="
+      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "requires": {
+        "source-list-map": "2.0.0",
+        "source-map": "0.5.7"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipsfx-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Webpack plugin for Unzipsfx - Create self-extracting compressed binaries Edit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Accounts for a project build that requires electron-rebuild of a node module, this will enable compiling as per arch instead of based on one .zip file 