### PR TITLE
Apply consistent zip file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function getPath(compilation, outputPath, outputFilename, extension) {
 }
 
 function compileArch(compilation, outputPath, outputFilename, arch, platform, callback) {
-  const zipFileName = (arch === "armv7l") ? `${outputFilename}-${arch}` : `${outputFilename}-${platform}-${arch}`;
+  const zipFileName = `${outputFilename}-${platform}-${arch}`;
   const zipFilePath = getPath(compilation, outputPath, zipFileName, ".zip");
   const unzipPath = (platform === "win") ? "/win/unzipsfx.exe" : `/${platform}-${arch}/unzipsfx`;
   const ext = (platform === "win") ? "exe" : "sh";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipsfx-webpack-plugin",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipsfx-webpack-plugin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Webpack plugin for Unzipsfx - Create self-extracting compressed binaries Edit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
display control will use this update to coincide with changes to the build to now include electron-rebuild of serialport for RPI